### PR TITLE
Added distinguishing fields for bearer token vs api key and tests for all auth types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/kosha/passthrough-connector
 go 1.18
 
 require (
-	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/prometheus/client_golang v1.12.2
+	github.com/stretchr/testify v1.8.1
 	github.com/swaggo/http-swagger v1.3.0
 	go.uber.org/zap v1.21.0
 )
@@ -14,7 +14,7 @@ require (
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
-	github.com/felixge/httpsnoop v1.0.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/go-openapi/spec v0.20.7 // indirect
@@ -24,11 +24,11 @@ require (
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
-	github.com/stretchr/testify v1.8.1 // indirect
 	github.com/swaggo/files v0.0.0-20220610200504-28940afbdbfe // indirect
 	github.com/swaggo/swag v1.8.3 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
@@ -39,4 +39,5 @@ require (
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,6 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
-github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -139,8 +137,6 @@ github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hf
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
-github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
-github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -1,0 +1,126 @@
+package app
+
+import (
+	"github.com/gorilla/mux"
+	"github.com/kosha/passthrough-connector/pkg/config"
+	"github.com/kosha/passthrough-connector/pkg/logger"
+	"os"
+	"testing"
+)
+
+var (
+	r *mux.Router
+	logging logger.Logger
+	redisAddr string
+)
+
+func init() {
+	r = mux.NewRouter().StrictSlash(true)
+	logging = logger.New("app", "passthrough-connector-test")
+}
+
+func TestMain(m *testing.M) {
+
+	//Run tests
+	code := m.Run()
+	os.Exit(code)
+
+}
+
+func TestApiKeyAuthCustomHeader(t *testing.T) {
+	t.Setenv("SERVER_URL", "http://httpbin.org")
+	t.Setenv("AUTH_TYPE", "API_KEY")
+	t.Setenv("API_KEY", "12345678")
+	t.Setenv("API_KEY_HEADER_NAME", "x-test-header")
+
+	cfg := config.Get()
+	a := App {
+		r,
+		logging,
+		cfg,
+	}
+	a.TestCommonMiddlewareApiKeyCustomHeader(t)
+}
+
+func TestApiKeyAuthDefaultHeader(t *testing.T) {
+	t.Setenv("SERVER_URL", "http://httpbin.org")
+	t.Setenv("AUTH_TYPE", "API_KEY")
+	t.Setenv("API_KEY", "12345678")
+
+	cfg := config.Get()
+	a := App {
+		r,
+		logging,
+		cfg,
+	}
+	a.TestCommonMiddlewareApiKeyDefaultHeader(t)
+}
+
+
+func TestBearerTokenAuth(t *testing.T) {
+
+	t.Setenv("SERVER_URL", "http://httpbin.org")
+	t.Setenv("AUTH_TYPE", "BEARER_TOKEN")
+	t.Setenv("BEARER_TOKEN", "test")
+
+	cfg := config.Get()
+	a := App{
+		r,
+		logging,
+		cfg,
+	}
+
+	a.TestCommonMiddlewareBearerToken(t)
+}
+
+func TestBasicAuth(t *testing.T) {
+
+	t.Setenv("SERVER_URL", "http://httpbin.org")
+	t.Setenv("AUTH_TYPE", "BASIC_AUTH")
+	t.Setenv("USERNAME", "foo")
+	t.Setenv("PASSWORD", "bar")
+
+	cfg := config.Get()
+	a := App{
+		r,
+		logging,
+		cfg,
+	}
+
+	a.TestCommonMiddlewareBasicAuth(t)
+}
+
+func TestHMAC(t *testing.T) {
+
+	t.Setenv("SERVER_URL", "http://httpbin.org")
+	t.Setenv("AUTH_TYPE", "HMAC")
+	t.Setenv("IKEY", "12345678")
+	t.Setenv("SKEY", "87654321")
+
+	cfg := config.Get()
+	a := App{
+		r,
+		logging,
+		cfg,
+	}
+
+	a.TestCommonMiddlewareHMAC(t)
+}
+
+func TestOAuth(t *testing.T) {
+
+	t.Setenv("SERVER_URL", "http://httpbin.org")
+	t.Setenv("AUTH_TYPE", "OAUTH2")
+	t.Setenv("ACCESS_TOKEN", "12345678")
+	t.Setenv("REFRESH_TOKEN", "87654321")
+	t.Setenv("EXPIRES_AT", "93048239")
+
+	cfg := config.Get()
+	a := App{
+		r,
+		logging,
+		cfg,
+	}
+
+	a.TestCommonMiddlewareOAuth(t)
+}

--- a/pkg/app/routes_test.go
+++ b/pkg/app/routes_test.go
@@ -23,6 +23,7 @@ func (a *App) TestCommonMiddlewareApiKeyCustomHeader(t *testing.T) {
 		a.Log.Errorf("can't unmarshalling response %v, error is: ", response.Body, err)
 	}
 
+	// checks to see if the custom header has been added to the request
 	val, ok := responseMap["headers"].(map[string]interface{})["X-Test-Header"].(string); if !ok || val != "12345678" {
 		t.Errorf("request header does not contain proper default api key header")
 	}
@@ -44,6 +45,8 @@ func (a *App) TestCommonMiddlewareApiKeyDefaultHeader(t *testing.T) {
 		a.Log.Errorf("can't unmarshalling response %v, error is: ", response.Body, err)
 	}
 
+
+	// checks to see if the default header has been added to the request
 	val, ok := responseMap["headers"].(map[string]interface{})["X"].(string); if !ok || val != "12345678" {
 		t.Errorf("request header does not contain proper default api key header")
 	}
@@ -52,6 +55,7 @@ func (a *App) TestCommonMiddlewareApiKeyDefaultHeader(t *testing.T) {
 
 func (a *App) TestCommonMiddlewareBearerToken(t *testing.T) {
 	req, err := http.NewRequest("GET", "", nil)
+	// this uri checks for a request with a bearer token attached
 	req.RequestURI = "/bearer"
 	if err != nil {
 		t.Fatal(err)
@@ -61,6 +65,7 @@ func (a *App) TestCommonMiddlewareBearerToken(t *testing.T) {
 
 func (a *App) TestCommonMiddlewareBasicAuth(t *testing.T) {
 	req, err := http.NewRequest("GET", "", nil)
+	// this uri checks for a request with basic auth with a username of foo and password of bar
 	req.RequestURI = "/basic-auth/foo/bar"
 	if err != nil {
 		t.Fatal(err)
@@ -84,6 +89,7 @@ func (a *App) TestCommonMiddlewareHMAC(t *testing.T) {
 		a.Log.Errorf("can't unmarshalling response %v, error is: ", response.Body, err)
 	}
 
+	// checks to see if the date header has been added to the request
 	_, ok := responseMap["headers"].(map[string]interface{})["Date"].(string); if !ok {
 		t.Errorf("request header does not contain proper HMAC date header")
 	}
@@ -91,6 +97,7 @@ func (a *App) TestCommonMiddlewareHMAC(t *testing.T) {
 
 func (a *App) TestCommonMiddlewareOAuth(t *testing.T) {
 	req, err := http.NewRequest("GET", "", nil)
+	// oauth also adds a bearer token so this makes sure there are no issues and the token has been added
 	req.RequestURI = "/bearer"
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/app/routes_test.go
+++ b/pkg/app/routes_test.go
@@ -1,0 +1,114 @@
+package app
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func (a *App) TestCommonMiddlewareApiKeyCustomHeader(t *testing.T) {
+	req, err := http.NewRequest("GET", "", nil)
+	req.RequestURI = "/headers"
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var responseMap map[string]interface{}
+
+	response := a.executeTest(t, req)
+
+	err = json.Unmarshal(response.Body.Bytes(), &responseMap)
+	if err != nil {
+		a.Log.Errorf("can't unmarshalling response %v, error is: ", response.Body, err)
+	}
+
+	val, ok := responseMap["headers"].(map[string]interface{})["X-Test-Header"].(string); if !ok || val != "12345678" {
+		t.Errorf("request header does not contain proper default api key header")
+	}
+}
+
+func (a *App) TestCommonMiddlewareApiKeyDefaultHeader(t *testing.T) {
+	req, err := http.NewRequest("GET", "", nil)
+	req.RequestURI = "/headers"
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var responseMap map[string]interface{}
+
+	response := a.executeTest(t, req)
+
+	err = json.Unmarshal(response.Body.Bytes(), &responseMap)
+	if err != nil {
+		a.Log.Errorf("can't unmarshalling response %v, error is: ", response.Body, err)
+	}
+
+	val, ok := responseMap["headers"].(map[string]interface{})["X"].(string); if !ok || val != "12345678" {
+		t.Errorf("request header does not contain proper default api key header")
+	}
+}
+
+
+func (a *App) TestCommonMiddlewareBearerToken(t *testing.T) {
+	req, err := http.NewRequest("GET", "", nil)
+	req.RequestURI = "/bearer"
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.executeTest(t, req)
+}
+
+func (a *App) TestCommonMiddlewareBasicAuth(t *testing.T) {
+	req, err := http.NewRequest("GET", "", nil)
+	req.RequestURI = "/basic-auth/foo/bar"
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.executeTest(t, req)
+}
+
+func (a *App) TestCommonMiddlewareHMAC(t *testing.T) {
+	req, err := http.NewRequest("GET", "", nil)
+	req.RequestURI = "/headers"
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var responseMap map[string]interface{}
+
+	response := a.executeTest(t, req)
+
+	err = json.Unmarshal(response.Body.Bytes(), &responseMap)
+	if err != nil {
+		a.Log.Errorf("can't unmarshalling response %v, error is: ", response.Body, err)
+	}
+
+	_, ok := responseMap["headers"].(map[string]interface{})["Date"].(string); if !ok {
+		t.Errorf("request header does not contain proper HMAC date header")
+	}
+}
+
+func (a *App) TestCommonMiddlewareOAuth(t *testing.T) {
+	req, err := http.NewRequest("GET", "", nil)
+	req.RequestURI = "/bearer"
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.executeTest(t, req)
+}
+
+func (a *App) executeTest(t *testing.T, req *http.Request) *httptest.ResponseRecorder{
+	// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
+	rr := httptest.NewRecorder()
+	handler := a.commonMiddleware()
+	// Our handlers satisfy http.Handler, so we can call their ServeHTTP method
+	// directly and pass in our Request and ResponseRecorder.
+	handler.ServeHTTP(rr, req)
+	// Check the status code is what we expect.
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+	return rr
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,6 +24,8 @@ type Config struct {
 
 func Get() *Config {
 	conf := &Config{}
+	// creating a new flagset everytime the get function is called allows for different flagsets to exist
+	// rather than a conflict to be created when generating a new config object (such as for tests)
 	flags := flag.NewFlagSet("Passthrough Flag Set", flag.PanicOnError)
 	flags.StringVar(&conf.username, "username", os.Getenv("USERNAME"), "Basic Auth username")
 	flags.StringVar(&conf.password, "password", os.Getenv("PASSWORD"), "Basic Auth password")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,6 +10,7 @@ import (
 type Config struct {
 	apiKey           string
 	apiKeyHeaderName string
+	bearerToken      string
 	serverUrl        string
 	username         string
 	password         string
@@ -23,19 +24,23 @@ type Config struct {
 
 func Get() *Config {
 	conf := &Config{}
-	flag.StringVar(&conf.username, "username", os.Getenv("USERNAME"), "Basic Auth username")
-	flag.StringVar(&conf.password, "password", os.Getenv("PASSWORD"), "Basic Auth password")
-	flag.StringVar(&conf.authType, "authType", os.Getenv("AUTH_TYPE"), "Auth Type")
-	flag.StringVar(&conf.apiKeyHeaderName, "apiKeyHeaderName", os.Getenv("API_KEY_HEADER_NAME"), "API Key Header Name")
-	flag.StringVar(&conf.apiKey, "apiKey", os.Getenv("API_KEY"), "API Key")
-	flag.StringVar(&conf.ikey, "ikey", os.Getenv("IKEY"), "Duo Security IKey")
-	flag.StringVar(&conf.sKey, "skey", os.Getenv("SKEY"), "Duo Security SKey")
-	flag.StringVar(&conf.serverUrl, "serverUrl", os.Getenv("SERVER_URL"), "Server Url")
-	flag.StringVar(&conf.accessToken, "accessToken", os.Getenv("ACCESS_TOKEN"), "Oauth2 Access Token")
-	flag.StringVar(&conf.refreshToken, "refreshToken", os.Getenv("REFRESH_TOKEN"), "Oauth2 Refresh Token")
-	flag.StringVar(&conf.expiresAt, "expiresAt", os.Getenv("EXPIRES_AT"), "Oauth2 Expires At")
+	flags := flag.NewFlagSet("Passthrough Flag Set", flag.PanicOnError)
+	flags.StringVar(&conf.username, "username", os.Getenv("USERNAME"), "Basic Auth username")
+	flags.StringVar(&conf.password, "password", os.Getenv("PASSWORD"), "Basic Auth password")
+	flags.StringVar(&conf.authType, "authType", os.Getenv("AUTH_TYPE"), "Auth Type")
+	flags.StringVar(&conf.apiKeyHeaderName, "apiKeyHeaderName", os.Getenv("API_KEY_HEADER_NAME"), "API Key Header Name")
+	flags.StringVar(&conf.apiKey, "apiKey", os.Getenv("API_KEY"), "API Key")
+	flags.StringVar(&conf.bearerToken, "bearerToken", os.Getenv("BEARER_TOKEN"), "Bearer Token")
+	flags.StringVar(&conf.ikey, "ikey", os.Getenv("IKEY"), "Duo Security IKey")
+	flags.StringVar(&conf.sKey, "skey", os.Getenv("SKEY"), "Duo Security SKey")
+	flags.StringVar(&conf.serverUrl, "serverUrl", os.Getenv("SERVER_URL"), "Server Url")
+	flags.StringVar(&conf.accessToken, "accessToken", os.Getenv("ACCESS_TOKEN"), "Oauth2 Access Token")
+	flags.StringVar(&conf.refreshToken, "refreshToken", os.Getenv("REFRESH_TOKEN"), "Oauth2 Refresh Token")
+	flags.StringVar(&conf.expiresAt, "expiresAt", os.Getenv("EXPIRES_AT"), "Oauth2 Expires At")
 
-	flag.Parse()
+	var arguments []string
+	arguments = append(arguments, "os.Environ")
+	flags.Parse(arguments)
 
 	return conf
 }
@@ -46,6 +51,10 @@ func (c *Config) GetApiKey() string {
 
 func (c *Config) GetApiKeyHeaderName() string {
 	return c.apiKeyHeaderName
+}
+
+func (c *Config) GetBearerToken() string {
+	return c.bearerToken
 }
 
 // GetAuthType returns the auth type accepted by the server


### PR DESCRIPTION
# Description

Added a new auth option for Bearer Token to separate it from the Api Key field. I also removed the Meraki field because it uses Api Key authentication. Also added tests for all auth types testing it against httpbin endpoints. Bearer token and basic auth have custom httpbin authentication endpoints, whereas other auth types are tested against header fields. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [X] Ran it with details for a bearer token API without issues
- [X] Ran tests using go test ./... to make sure all auth types are working

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
https://cisco-eti.atlassian.net/wiki/spaces/KOSH/pages/37093405/Building+a+Kosha+Connector+using+the+Passthrough+Connector
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

[https://github.com/Cisco-Kosha/openai-api-spec/blob/main/connector_spec.json](https://github.com/Cisco-Kosha/openai-api-spec/blob/main/connector_spec.json)

[https://github.com/Cisco-Kosha/stripe-api-spec/blob/main/connector_spec.json](https://github.com/Cisco-Kosha/stripe-api-spec/blob/main/connector_spec.json)

[https://github.com/Cisco-Kosha/webex-api-spec/blob/main/connector_spec.json](https://github.com/Cisco-Kosha/webex-api-spec/blob/main/connector_spec.json)