### PR TITLE
Added no auth option + tests

### DIFF
--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -27,6 +27,19 @@ func TestMain(m *testing.M) {
 
 }
 
+func TestNoAuth(t *testing.T) {
+	t.Setenv("SERVER_URL", "http://httpbin.org")
+	t.Setenv("AUTH_TYPE", "NONE")
+
+	cfg := config.Get()
+	a := App {
+		r,
+		logging,
+		cfg,
+	}
+	a.TestCommonMiddlewareNoAuth(t)
+}
+
 func TestApiKeyAuthCustomHeader(t *testing.T) {
 	t.Setenv("SERVER_URL", "http://httpbin.org")
 	t.Setenv("AUTH_TYPE", "API_KEY")

--- a/pkg/app/routes.go
+++ b/pkg/app/routes.go
@@ -16,6 +16,7 @@ const (
 	BasicAuth   = "BASIC_AUTH"
 	HMAC        = "HMAC"
 	Oauth       = "OAUTH2"
+	None        = "NONE"
 )
 
 func (a *App) commonMiddleware() http.Handler {
@@ -74,6 +75,18 @@ func (a *App) commonMiddleware() http.Handler {
 
 		authType := a.Cfg.GetAuthType()
 		switch authType {
+		case None:
+			res, statusCode, err := httpclient.MakeHttpNoAuthCall(headers, method, serverUrl, c, a.Log)
+			if err != nil {
+				a.Log.Errorf("Encountered an error while making a call: %v\n", err)
+				respondWithError(w, statusCode, err.Error())
+				return
+			}
+			if (statusCode != 200) && (statusCode != 201) && res != nil {
+				a.Log.Errorf("Http response has a non-successful status code of %v with body %v", statusCode, res)
+			}
+			respondWithJSON(w, statusCode, res)
+			return
 		case ApiKey:
 			apiKeyHeaderName := a.Cfg.GetApiKeyHeaderName()
 			apiKey := a.Cfg.GetApiKey()

--- a/pkg/app/routes_test.go
+++ b/pkg/app/routes_test.go
@@ -7,6 +7,17 @@ import (
 	"testing"
 )
 
+func (a *App) TestCommonMiddlewareNoAuth(t *testing.T) {
+	req, err := http.NewRequest("GET", "", nil)
+	req.RequestURI = "/headers"
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a.executeTest(t, req)
+}
+
+
 func (a *App) TestCommonMiddlewareApiKeyCustomHeader(t *testing.T) {
 	req, err := http.NewRequest("GET", "", nil)
 	req.RequestURI = "/headers"


### PR DESCRIPTION
# Description

In the connector onboarding process, there's an option for a user to upload an Open API spec for an API has no authentication scheme. This is a rare case, but we want to support it as it's as simple as it gets. I've added the code to have the "NONE" option for auth type with a test that checks against the http://httpbin.org/headers endpoint and makes sure it goes through without any issues.

Include the below if associated with a JIRA issue:
Fixes # KOSH-403

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# Checklist:

- [X ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
https://cisco-eti.atlassian.net/wiki/spaces/KOSH/pages/37093405/Building+a+Kosha+Connector+using+the+Passthrough+Connector
- [X] I have added tests that prove my fix is effective or that my feature works
- [X ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
